### PR TITLE
Fixing extension set up

### DIFF
--- a/extension/build_once.sh
+++ b/extension/build_once.sh
@@ -1,0 +1,5 @@
+rm -rf build/*
+cp -r src/* build
+webpack-cli  --config ./webpack.config.js --entry ./src/popup.js -o build/popup.js &
+webpack-cli  --config ./webpack.config.js --entry ./src/js/background/index.js -o build/js/background.js &
+webpack-cli  --config ./webpack.config.js --entry ./src/js/inject/index.js -o build/js/inject.js &

--- a/extension/build_script.sh
+++ b/extension/build_script.sh
@@ -1,6 +1,6 @@
 rm -rf build/*
 cp -r src/* build
-node html_to_string.js
-webpack-cli  --config ./webpack.config.js --watch --entry ./src/js/inject/index.js -o build/js/inject.js &
-webpack-cli  --config ./webpack.config.js --watch --entry ./src/js/background/index.js -o build/js/background.js &
-echo "done"
+webpack-cli  --config ./webpack.config.js --watch --entry ./src/popup.js -o build/popup.js &
+webpack-cli  --config ./webpack.config.js --watch --entry ./src/manifest.json -o build/manifest.json &
+webpack-cli  --config ./webpack.config.js --watch --entry ./src/js/background/index.js -o build/js/background/index.js &
+echo "Watching over 3 files for changes, popup.js mainfest.json and js/background/index.js, if this is run multiple times you may want to run 'killall' node in the command line"

--- a/extension/build_script.sh
+++ b/extension/build_script.sh
@@ -1,6 +1,6 @@
 rm -rf build/*
 cp -r src/* build
 webpack-cli  --config ./webpack.config.js --watch --entry ./src/popup.js -o build/popup.js &
-webpack-cli  --config ./webpack.config.js --watch --entry ./src/manifest.json -o build/manifest.json &
-webpack-cli  --config ./webpack.config.js --watch --entry ./src/js/background/index.js -o build/js/background/index.js &
-echo "Watching over 3 files for changes, popup.js mainfest.json and js/background/index.js, if this is run multiple times you may want to run 'killall' node in the command line"
+webpack-cli  --config ./webpack.config.js --watch --entry ./src/js/background/index.js -o build/js/background.js &
+webpack-cli  --config ./webpack.config.js --watch --entry ./src/js/inject/index.js -o build/js/inject.js &
+echo "Watching over 3 javascript files for changes, popup.jsand js/background/index.js, if this is run multiple times you may want to run 'killall' node in the command line"

--- a/extension/package.json
+++ b/extension/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "build": "bash build_script.sh",
-    "watch": "webpack --watch"
+    "build-once": "bash build_once.sh"
   },
   "dependencies": {
     "media-recorder-stream": "^2.1.1",


### PR DESCRIPTION
There was a bug where if you do: npm run build and you've run it before it'll create another process, now to watch files you can run **NPM run build** as usual!
but if a file is not being watched and you need to re run the build, to run the build ONCE and not watch files, run **NPM run build-once**