### PR TITLE
60 FPS Video Streaming

### DIFF
--- a/extension/src/HomeView.vue
+++ b/extension/src/HomeView.vue
@@ -15,18 +15,26 @@
       @keydown.enter="startShare"
     ></v-text-field>
 
-    <v-checkbox 
+      <v-checkbox 
       style="margin-bottom: 0%; margin-top: -5%; margin-left: 5%;"
       label="Share Screen"
       color="primary"
       @change="toggleScreenShare"
       >
       </v-checkbox>
+      
+      <v-switch
+      label="60 FPS"
+      style="margin-bottom: 0%; margin-left: 5%; margin-top: -5%;"
+      color="primary"
+      @change="toggle60FpsVideo"
+      >
+      </v-switch>
 
       <v-checkbox 
       style="margin-bottom: 0%; margin-top: -5%; margin-left: 5%;"
-      label="Distributed Streaming System (Experimental)"
-      color="primary"
+      label="Distributed Streaming (Experimental)"
+      color="red"
       @change="toggleDistributedStreaming"
       >
       </v-checkbox>
@@ -56,7 +64,7 @@ export default {
     ...mapState(["roomName", "roomNameValid", "roomNameInputErrorMessages"])
   },
   methods: {
-    ...mapActions(["randomRoomName", "startShare", "toggleScreenShare", "toggleDistributedStreaming"]),
+    ...mapActions(["randomRoomName", "startShare", "toggleScreenShare", "toggleDistributedStreaming", "toggle60FpsVideo"]),
     ...mapMutations(["setRoomName"])
   }
 };

--- a/extension/src/app.js
+++ b/extension/src/app.js
@@ -157,6 +157,11 @@ const store = new Vuex.Store({
             if(this.state.state === States.HOME) {
                 port.postMessage({ type: 'toggleDistributedStreaming', useDistributedStreaming: checked });
             }
+        },
+        toggle60FpsVideo(context, value) {
+            if(this.state.state === States.HOME) {
+                port.postMessage({ type: "toggle60Fps", selected: value });
+            }
         }
     }
 })
@@ -186,10 +191,13 @@ chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
         store.commit("setState", request.data);
         if(store.state.state === States.HOME) { 
             router.push({name: 'home'}).catch((err) => {});
+            // reset states of media variables to match state of selection controls
             store.dispatch("toggleScreenShare", false);
+            store.dispatch("toggle60FpsVideo", false);
         }
         else if(store.state.state === States.SHARING) { 
             router.push({name: "sharing"}).catch((err) => {});
+            app.$el.getElementsByClassName('v-application--wrap')[0].style.minHeight = "50vH"
         }
     }
 });


### PR DESCRIPTION
Added option to force 60 FPS video streaming. The extension UI dynamically changes height based on state of the app (Taller for HOME, shorter for SHARING) to only occupy the minimum required screen space. 

Fixes #138 