### PR TITLE
fix(darkmode): add color class for text from active darkmode

### DIFF
--- a/packages/app/src/App.vue
+++ b/packages/app/src/App.vue
@@ -12,22 +12,26 @@
         style="width: 300px"
       >
         <q-card-section>
-          <div style="color:#343434;" class="text-h6">Are you using Chrome?</div>
+          <div
+            class="text-h6"
+            :class="$q.dark.isActive ? 'text-white' : 'text-grey-9'">Are you using Chrome?</div>
         </q-card-section>
 
-        <q-card-section style="color:#343434;" class="q-pt-none">
+        <q-card-section
+          :class="$q.dark.isActive ? 'text-white' : 'text-grey-9'"
+          class="q-pt-none">
           For the optimal Toonin experience on desktop and mobile, we recommend using Google Chrome.
         </q-card-section>
 
         <q-card-actions
           align="right"
-          class="bg-white"
+          :class="$q.dark.isActive ? 'bg-dark' : 'bg-white'"
         >
           <q-btn
             flat
             label="I understand"
             v-close-popup
-            style="color:#343434;"
+            :class="$q.dark.isActive ? 'text-white' : 'text-grey-9'"
             @click="showBrowserCompatDialog = false"
           />
         </q-card-actions>


### PR DESCRIPTION
This correction solves the problem of the dialog in the dark mode of the application making the text readable and color dynamic.

normal mode:

<img width="731" alt="Captura de Tela 2020-10-28 às 02 25 47" src="https://user-images.githubusercontent.com/13258255/97395974-e5068b00-18c4-11eb-956f-d786b24082d4.png">

dark mode: 

<img width="746" alt="Captura de Tela 2020-10-28 às 02 26 08" src="https://user-images.githubusercontent.com/13258255/97396001-f0f24d00-18c4-11eb-9f34-2236850252bd.png">


Fixes #234 
